### PR TITLE
Enable SSL for apache2 (PHP5.6)

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -120,6 +120,7 @@ RUN a2enmod		\
   rewrite 		\
   setenvif 		\
   status 		\
+  ssl 		\
   && a2dismod cgi
 
 # Install composer (latest version)


### PR DESCRIPTION
IMO, it's necessary to enable by default the ssl module for apache. I propose adding ssl to the a2enmod command.